### PR TITLE
Relative path needed for static files

### DIFF
--- a/httpdispatcher.js
+++ b/httpdispatcher.js
@@ -76,7 +76,7 @@ HttpDispatcher.prototype.dispatch = function(req, res) {
 }
 HttpDispatcher.prototype.staticListener =  function(req, res) {
 	var url = require('url').parse(req.url, true);
-	var filename = require('path').join(this.staticDirname, url.pathname);
+	var filename = "." + require('path').join(this.staticDirname, url.pathname);
 	var errorListener = this.errorListener;
 	require('fs').readFile(filename, function(err, file) {
 		if(err) {


### PR DESCRIPTION
It's trying to open the absolute path instead of the relative path for static files, so it's throwing 404 errors.

There may be another workaround, but this is how I fixed it.