### PR TITLE
Export module 'constructor' instead of just a single new object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Classes http.ServerRequest and http.ServerResponse earns new params property con
 Using httpdispatcher is pretty simple:
 
 ```js
-	var dispatcher = require('../httpdispatcher');
-	var http = require('http');
+	var HttpDispatcher = require('../httpdispatcher');
+	var http           = require('http');
+	var dispatcher     = new HttpDispatcher();
 
 	dispatcher.setStatic('/resources');
 	dispatcher.setStaticDirname('static');
@@ -43,10 +44,10 @@ Using httpdispatcher is pretty simple:
 	
 	
 	/*
-	GET /page1 => 'Page One'
-	POST /page2 => 'Page Two'
-	GET /page3 => 404
-	GET /resources/images-that-exists.png => Image resource
-	GET /resources/images-that-does-not-exists.png => 404
+	GET  /page1  => 'Page One'
+	POST /page2  => 'Page Two'
+	GET  /page3  => 404
+	GET  /resources/images-that-exists.png => Image resource
+	GET  /resources/images-that-does-not-exists.png => 404
 	*/
 ```	

--- a/httpdispatcher.d.ts
+++ b/httpdispatcher.d.ts
@@ -1,0 +1,116 @@
+// Type definitions for httpdispatcher
+// Project: https://github.com/alberto-bottarini/httpdispatcher
+// Definitions by: Chris Barth <https://github.com/cjbarth>
+
+/// <reference path="../node/node" />
+
+declare module "httpdispatcher" {
+	import Http = require('http');
+
+	export interface Callback {
+		(request: Http.ClientRequest, response: Http.ServerResponse): void;
+	}
+
+	export interface UrlMatcher {
+		(url:string): boolean;
+	}
+
+	/**
+	 * Generic function to set up request listener. Prefer onGet and onPost instead.
+	 * @param method - The HTTP method to response to: "get" or "post"
+	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function on(method:string, url:string|RegExp|UrlMatcher, callback:Callback):void;
+
+	/**
+	 * Generic function to set up request filters. Prefer beforeFilter and afterFilter instead.
+	 * @param method - Should this filter be applied "before" or "after" the request is processed?
+	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function filter(method:string, url:string|RegExp|UrlMatcher, callback:Callback):void;
+
+	/**
+	 * What to do when a GET reqeust matches _url_.
+	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function onGet(url:string|RegExp|UrlMatcher, callback:Callback):void;
+
+	/**
+	 * What to do when a POST request matches _url_.
+	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function onPost(url:string|RegExp|UrlMatcher, callback:Callback):void;
+
+	/**
+	 * What function should be called when there is an error.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function onError(callback:Callback):void;
+
+	/**
+	 * Set the virtual folder for the static resources.
+	 * @param folder - Relative path in URL to static resources.
+	 */
+	export function setStatic(folder:string):void;
+
+	/**
+	 * Set the physical/local folder for the static resources.
+	 * @param dirname - Relative path in file system to static resources.
+	 */
+	export function setStaticDirname(dirname:string):void;
+
+	/**
+	 * Called before a route is handeled; can modify the request and response.
+	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function beforeFilter(url:string|RegExp|UrlMatcher, callback:Callback):void;
+
+	/**
+	 * Called after a route is handeled; can modify the request and response.
+	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param callback - The function that will be called on match.
+	 */
+	export function afterFilter(url:string|RegExp|UrlMatcher, callback:Callback):void;
+
+	/**
+	 * Main entry point for httpdispatcher. Http.CreateServer would call this.
+	 * @param request - A ClientRequest object from NodeJS _Http_ module.
+	 * @param response - A ClientResponse object from NodeJS _Http_ module.
+	 */
+	export function dispatch(request:Http.ClientRequest, response:Http.ServerResponse):void;
+
+	/**
+	 * Listen to requests for static assests and serve them from the file system.
+	 * @param request - A ClientRequest object from NodeJS _Http_ module.
+	 * @param response - A ClientResponse object from NodeJS _Http_ module.
+	 */
+	export function staticListener(request:Http.ClientRequest, response:Http.ServerResponse):void;
+
+	/**
+	 * Return the Callback that matches the URL and method requested.
+	 * @param url - The URL requested.
+	 * @param method - The method, "get" or "post", that the URL was requested with.
+	 * @returns Callback
+	 */
+	export function getListener(url:string, method:string):Callback;
+
+	/**
+	 * Return the Callback filter that matches the URL and method requested.
+	 * @param url - The URL requested.
+	 * @param type - The type of the filter, "before" or "after, for which the Callback should be returned.
+	 * @returns Callback
+	 */
+	export function getFilters(url:string, type:string):Callback;
+
+	/**
+	 * Will determine if there is a match for a _url_ given a _config_.
+	 * @param config - String, RegExp, or Function that will match and/or return true with a provided URL string.
+	 * @param url - The string that will be passed to config() or compared (==) with config or matched with config.test() to return a boolean.
+	 */
+	export function urlMatches(config:string|RegExp|UrlMatcher, url:string):boolean;
+}

--- a/httpdispatcher.js
+++ b/httpdispatcher.js
@@ -1,9 +1,15 @@
 var util = require('util');
 var path = require('path');
 var HttpDispatcher = function() {
-	this.listeners = { get: [ ], post: [ ] };
+	this.listeners = {
+		'head' : [ ],
+		'get' : [ ],
+		'post': [ ],
+		'put' : [ ],
+		'delete' : [ ]
+	};
 	this.filters = { before: [ ], after: [ ] };
-	this.errorListener = function(req, res) { 
+	this.errorListener = function(req, res) {
 		res.writeHead(404);
 		res.end();
 	}
@@ -22,11 +28,20 @@ HttpDispatcher.prototype.filter = function(method, url, cb) {
 		url: url
 	});
 }
+HttpDispatcher.prototype.onHead = function(url, cb) {
+	this.on('head', url, cb);
+}
 HttpDispatcher.prototype.onGet = function(url, cb) {
 	this.on('get', url, cb);
-}	
+}
 HttpDispatcher.prototype.onPost = function(url, cb) {
 	this.on('post', url, cb);
+}
+HttpDispatcher.prototype.onPut = function(url, cb) {
+	this.on('put', url, cb);
+}
+HttpDispatcher.prototype.onDelete = function(url, cb) {
+	this.on('delete', url, cb);
 }
 HttpDispatcher.prototype.onError = function(cb) {
 	this.errorListener = cb;
@@ -99,9 +114,11 @@ HttpDispatcher.prototype.staticListener =  function(req, res) {
 	});
 }
 HttpDispatcher.prototype.getListener = function(url, method) {
-	for(var i = 0, listener; i<this.listeners[method].length; i++) {
-		listener = this.listeners[method][i];
-		if(this.urlMatches(listener.url, url)) return listener.cb;
+	if (this.listeners[method]) {
+		for(var i = 0, listener; i<this.listeners[method].length; i++) {
+			listener = this.listeners[method][i];
+			if(this.urlMatches(listener.url, url)) return listener.cb;
+		}
 	}
 }
 HttpDispatcher.prototype.getFilters = function(url, type) {


### PR DESCRIPTION
I was having issues when I needed multiple HttpDispatcher objects because it was only returning a single instance on require(). Changed module to return HttpDispatcher 'constructor' instead.

I also merged in your other two pull requests (TypeScript support and additional HTTP request methods).