### PR TITLE
Adding options call for CORS possible support

### DIFF
--- a/httpdispatcher.js
+++ b/httpdispatcher.js
@@ -6,7 +6,8 @@ var HttpDispatcher = function() {
 		'get'   : [ ],
 		'post'  : [ ],
 		'put'   : [ ],
-		'delete': [ ]
+		'delete': [ ],
+		'options': [ ]
 	};
 	this.filters            = { before: [ ], after: [ ] };
 	this.errorListener      = function(req, res) {
@@ -41,6 +42,10 @@ HttpDispatcher.prototype.onGet = function(url, cb) {
 
 HttpDispatcher.prototype.onPost = function(url, cb) {
 	this.on('post', url, cb);
+};
+
+HttpDispatcher.prototype.onOptions = function(url, cb) {
+	this.on('options', url, cb);
 };
 
 HttpDispatcher.prototype.onPut = function(url, cb) {


### PR DESCRIPTION
A user might be using this server with a front end that required CORS support. This options call will allow the user to send the correct header for the OPTIONS call to allow CORS>
