### PR TITLE
Correct TypeScript type definitions

### DIFF
--- a/httpdispatcher.d.ts
+++ b/httpdispatcher.d.ts
@@ -2,18 +2,12 @@
 // Project: https://github.com/alberto-bottarini/httpdispatcher
 // Definitions by: Chris Barth <https://github.com/cjbarth>
 
-/// <reference path="../node/node" />
+import Http = require('http');
 
-declare module "httpdispatcher" {
-	import Http = require('http');
+export = HttpDispatcher;
 
-	export interface Callback {
-		(request: Http.ClientRequest, response: Http.ServerResponse): void;
-	}
-
-	export interface UrlMatcher {
-		(url:string): boolean;
-	}
+declare class HttpDispatcher {
+	constructor();
 
 	/**
 	 * Generic function to set up request listener. Prefer onGet and onPost instead.
@@ -21,7 +15,7 @@ declare module "httpdispatcher" {
 	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function on(method:string, url:string|RegExp|UrlMatcher, callback:Callback):void;
+	on(method:string, url:string|RegExp|HttpDispatcher.UrlMatcher, callback:HttpDispatcher.Callback):void;
 
 	/**
 	 * Generic function to set up request filters. Prefer beforeFilter and afterFilter instead.
@@ -29,67 +23,67 @@ declare module "httpdispatcher" {
 	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function filter(method:string, url:string|RegExp|UrlMatcher, callback:Callback):void;
+	filter(method:string, url:string|RegExp|HttpDispatcher.UrlMatcher, callback:HttpDispatcher.Callback):void;
 
 	/**
 	 * What to do when a GET reqeust matches _url_.
 	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function onGet(url:string|RegExp|UrlMatcher, callback:Callback):void;
+	onGet(url:string|RegExp|HttpDispatcher.UrlMatcher, callback:HttpDispatcher.Callback):void;
 
 	/**
 	 * What to do when a POST request matches _url_.
 	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function onPost(url:string|RegExp|UrlMatcher, callback:Callback):void;
+	onPost(url:string|RegExp|HttpDispatcher.UrlMatcher, callback:HttpDispatcher.Callback):void;
 
 	/**
 	 * What function should be called when there is an error.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function onError(callback:Callback):void;
+	onError(callback:HttpDispatcher.Callback):void;
 
 	/**
 	 * Set the virtual folder for the static resources.
 	 * @param folder - Relative path in URL to static resources.
 	 */
-	export function setStatic(folder:string):void;
+	setStatic(folder:string):void;
 
 	/**
 	 * Set the physical/local folder for the static resources.
 	 * @param dirname - Relative path in file system to static resources.
 	 */
-	export function setStaticDirname(dirname:string):void;
+	setStaticDirname(dirname:string):void;
 
 	/**
 	 * Called before a route is handeled; can modify the request and response.
 	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function beforeFilter(url:string|RegExp|UrlMatcher, callback:Callback):void;
+	beforeFilter(url:string|RegExp|HttpDispatcher.UrlMatcher, callback:HttpDispatcher.ChainCallback):void;
 
 	/**
 	 * Called after a route is handeled; can modify the request and response.
 	 * @param url - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param callback - The function that will be called on match.
 	 */
-	export function afterFilter(url:string|RegExp|UrlMatcher, callback:Callback):void;
+	afterFilter(url:string|RegExp|HttpDispatcher.UrlMatcher, callback:HttpDispatcher.ChainCallback):void;
 
 	/**
 	 * Main entry point for httpdispatcher. Http.CreateServer would call this.
 	 * @param request - A ClientRequest object from NodeJS _Http_ module.
 	 * @param response - A ClientResponse object from NodeJS _Http_ module.
 	 */
-	export function dispatch(request:Http.ClientRequest, response:Http.ServerResponse):void;
+	dispatch(request:Http.IncomingMessage, response:Http.ServerResponse):void;
 
 	/**
 	 * Listen to requests for static assests and serve them from the file system.
 	 * @param request - A ClientRequest object from NodeJS _Http_ module.
 	 * @param response - A ClientResponse object from NodeJS _Http_ module.
 	 */
-	export function staticListener(request:Http.ClientRequest, response:Http.ServerResponse):void;
+	staticListener(request:Http.IncomingMessage, response:Http.ServerResponse):void;
 
 	/**
 	 * Return the Callback that matches the URL and method requested.
@@ -97,7 +91,7 @@ declare module "httpdispatcher" {
 	 * @param method - The method, "get" or "post", that the URL was requested with.
 	 * @returns Callback
 	 */
-	export function getListener(url:string, method:string):Callback;
+	getListener(url:string, method:string):HttpDispatcher.Callback;
 
 	/**
 	 * Return the Callback filter that matches the URL and method requested.
@@ -105,12 +99,44 @@ declare module "httpdispatcher" {
 	 * @param type - The type of the filter, "before" or "after, for which the Callback should be returned.
 	 * @returns Callback
 	 */
-	export function getFilters(url:string, type:string):Callback;
+	getFilters(url:string, type:string):HttpDispatcher.Callback;
 
 	/**
 	 * Will determine if there is a match for a _url_ given a _config_.
 	 * @param config - String, RegExp, or Function that will match and/or return true with a provided URL string.
 	 * @param url - The string that will be passed to config() or compared (==) with config or matched with config.test() to return a boolean.
 	 */
-	export function urlMatches(config:string|RegExp|UrlMatcher, url:string):boolean;
+	urlMatches(config:string|RegExp|HttpDispatcher.UrlMatcher, url:string):boolean;
+
+}
+
+declare namespace HttpDispatcher {
+
+	export interface ClientRequest extends Http.IncomingMessage {
+		params: object,
+		/// available only on POST requests
+		body?: string,
+		/// available only on POST requests
+		bodyBuffer?: Buffer,
+	}
+
+	export class HttpChain {
+		constructor();
+		add(callback: ChainCallback): void;
+		addAll(callbacks: ChainCallback[]): void;
+		next(req: ClientRequest, res: Http.ServerResponse): void;
+	}
+
+	export interface Callback {
+		(request: ClientRequest, response: Http.ServerResponse): void;
+	}
+
+	export interface ChainCallback {
+		(request: ClientRequest, response: Http.ServerResponse, chain: HttpChain): void;
+	}
+
+	export interface UrlMatcher {
+		(url:string): boolean;
+	}
+
 }


### PR DESCRIPTION
This PR updates the TypeScript definitions of this library to match the module as it currently exists, while making the definition compatible with the latest TypeScript compiler. Most of the changes are in line with best practices found in the TypeScript website and the [module class template](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html).

- remake module into class declaration HttpDispatcher
- export HttpDispatcher as CommonJS default
- do not use <reference path> directive, as it is a bad practice; having the import of the http module is enough
- provide a more specific `ClientRequest` based on the information given in the readme file (extends `IncomingMessage`; note that http's `ClientRequest` is for request objects on the client side)
- add a public-facing declaration for HttpChain, so that it can be used by consumers of the module
- add ChainCallback for callback fns with a chain as 3rd arg, so that TypeScript expects 3 arguments in `beforeFilter` and `afterFilter`

Feel free to let me know if there is something more you'd like addressed here.